### PR TITLE
Write multiple ADIR/META entries for pack assets with multiple names

### DIFF
--- a/lib/src/format/mod.rs
+++ b/lib/src/format/mod.rs
@@ -540,7 +540,7 @@ impl Debug for CObjectId {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result { write!(f, "{:?}", self.0) }
 }
 
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, PartialEq)]
 #[repr(C, packed)]
 pub struct ByteOrderUuid<O: ByteOrder> {
     inner: uuid::Bytes,


### PR DESCRIPTION
Fixes repacking GuiSysMP1.pak. This is my first time writing Rust, so apologies if I've mangled anything.